### PR TITLE
chore: Update package.json to point to the published guardian-manament-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "express-jwt": "^3.4.0",
     "express-jwt-permissions": "^0.2.2",
     "express-session": "^1.14.0",
-    "guardian-management-client": "file:./deps/guardian-management-client-1.0.1.tgz",
+    "guardian-management-client": "auth0/guardian-management-client.git",
     "jsonwebtoken": "^7.1.6",
     "jwt-decode": "^2.0.1",
     "lodash": "^4.13.1",


### PR DESCRIPTION
This version was previously unpublished